### PR TITLE
reactToString includes null check option

### DIFF
--- a/src/react-to-string.js
+++ b/src/react-to-string.js
@@ -1,5 +1,5 @@
 const reactToString = element => {
-  if (typeof element === 'string') {
+  if (typeof element === 'string' || element === null) {
     return element;
   }
 

--- a/test/react-to-string.test.js
+++ b/test/react-to-string.test.js
@@ -6,6 +6,11 @@ test('Returns the original string if the element is a string', () => {
   expect(reactToString(testString)).toBe(testString);
 });
 
+test('Returns the null element if the element is null', () => {
+  const nullElement = null;
+  expect(reactToString(nullElement)).toBe(nullElement);
+})
+
 test('Returns the string child of an element that only has one child', () => {
   const testElement = <div>This is a test string</div>
   expect(reactToString(testElement)).toBe('This is a test string');


### PR DESCRIPTION
Summary
---
reactToString function did not account for null elements. If any of the children of the React element is null, or the element itself is null, then reactToString breaks trying to access props. 

Changes proposed
---
This pull request adds a null check and returns the element if null.