### PR TITLE
Support numbers, undefined, unknown objects

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,11 @@
   "version": "0.0.2",
   "description": "Convert React elements to strings",
   "author": "Kevin Huang <kevin.ziwen.huang@gmail.com>",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/kevinzwhuang/react-to-string.git"
+  },
+  "homepage": "https://github.com/kevinzwhuang/react-to-string",
   "files": [
     "dist",
     "README.md"

--- a/src/react-to-string.js
+++ b/src/react-to-string.js
@@ -1,6 +1,14 @@
 const reactToString = element => {
-  if (typeof element === 'string' || element === null) {
+  if (!element) {
+    return '';
+  }
+
+  if (typeof element === 'string') {
     return element;
+  }
+
+  if (typeof element === 'number') {
+    return String(element);
   }
 
   if (Array.isArray(element)) {
@@ -14,6 +22,8 @@ const reactToString = element => {
   if (element.props && !element.props.children) {
     return '';
   }
+
+  return '';
 }
 
 export default reactToString;

--- a/test/react-to-string.test.js
+++ b/test/react-to-string.test.js
@@ -7,8 +7,11 @@ test('Returns the original string if the element is a string', () => {
 });
 
 test('Returns the null element if the element is null', () => {
-  const nullElement = null;
-  expect(reactToString(nullElement)).toBe(nullElement);
+  expect(reactToString(null)).toBe('');
+})
+
+test('Returns the empty string if the element is not passed', () => {
+  expect(reactToString()).toBe('');
 })
 
 test('Returns the string child of an element that only has one child', () => {
@@ -39,4 +42,12 @@ test('Returns only the string children of an element with mixed children (React 
 test('Returns an empty string if element has no children', () => {
   const testElement = <br />
   expect(reactToString(testElement)).toBe('');
+});
+
+test('Returns an string if element is number', () => {
+  expect(reactToString(42)).toBe('42');
+});
+
+test('Returns an empty string if element is unprocessable object', () => {
+  expect(reactToString({ foo: 'bar' })).toBe('');
 });


### PR DESCRIPTION
Hi!

Originally I faced with the issue that your code just skips numbers among react children. But in process of fixing it - I've added a few more improvements from my point of view.

The main idea is if package name `react-to-string` it means that you always must expect it returns a `string`. That's why I've added next:

1. Fix `number` type as argument
2. Add default return an empty string if none of `if` conditions are true. For example handling of objects with unknown structure (e.g. `{ foo: 'bar' }`)
3. Add check for nullable argument. Be aware that this is breaking change. I hope you agree `reactToString` shouldn't return `null`.

And minor things to `package.json` just for NPM mostly.

Hope you like it and I'll be able to remove workaround I have now like `String(reactToString(42))`.

Thanks, 
Leo.